### PR TITLE
1. added a quick text-diff viz tool for checkpoints in CuriosityAgent…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,16 @@ dependencies = [
     "networkx>=3.2",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
+    "neo4j",
+    "langchain-openai",
+    "langchain-core",
+    "langchain-anthropic",
+    "langchain-community",
+    "langchain-experimental",
+    "faker>=24.8.0",
+    "rich>=13.7.1"
 ]
+
 
 [build-system]
 requires = ["hatchling"]
@@ -29,4 +38,11 @@ addopts = "-ra -q"
 
 [tool.ruff]
 line-length = 88
-target-version = "py312" 
+target-version = "py312"
+
+[tool.poetry.dependencies]
+faker = "^24.8.0"
+python = "^3.9"
+langgraph = "^0.0.34"
+langchain-core = "^0.2.0"
+rich = "^13.7.1" 

--- a/src/amadeus_burger/agents/base.py
+++ b/src/amadeus_burger/agents/base.py
@@ -2,20 +2,23 @@ from typing import Any, Sequence
 from datetime import datetime
 from langchain_core.messages import BaseMessage
 from typing_extensions import TypedDict
-
+from abc import ABC, abstractmethod
 from amadeus_burger.constants.settings import Settings
 
-class AgentPipeline:
+class AgentPipeline(ABC):
     def __init__(self, llm: str | None = None):
         self.llm = llm or Settings.llm
         
+    @abstractmethod
     def get_current_state(self) -> dict[str, Any]:
         """Get current state of the pipeline"""
-        raise NotImplementedError
+        pass
         
+    @abstractmethod
     def run(self, initial_input: Any) -> Any:
-        raise NotImplementedError
+        pass
         
+    @abstractmethod
     def get_config(self) -> dict[str, Any]:
-        raise NotImplementedError
+        pass
 

--- a/src/amadeus_burger/agents/nodes/__init__.py
+++ b/src/amadeus_burger/agents/nodes/__init__.py
@@ -1,0 +1,8 @@
+from amadeus_burger.agents.nodes.knowledge_base_node import *
+from amadeus_burger.agents.nodes.final_answer_node import *
+from amadeus_burger.agents.nodes.curiosity_node import *
+from amadeus_burger.agents.nodes.novelty_evaluator_node import *
+from amadeus_burger.agents.nodes.web_search_node import *
+from amadeus_burger.agents.nodes.knowledge_ingestion_node import *
+
+

--- a/src/amadeus_burger/agents/tools/__init__.py
+++ b/src/amadeus_burger/agents/tools/__init__.py
@@ -1,0 +1,1 @@
+from amadeus_burger.agents.tools.knowledge_base_fetcher_tool import *


### PR DESCRIPTION
主要改動 (在 pipelines_sam.py):
加入遞迴限制 (recursion_limit=10)
新增 loop_counter 防止無限循環
新增狀態追蹤與視覺化功能（包含 checkpoint tuple 的存取）
加入可執行的範例程式（在 if __name__ == "__main__" 區塊）
使用 Faker 產生測試資料
展示完整的 pipeline 執行流程
實際驗證 pipeline 可以運作
相依套件:
在 pyproject.toml 加入 rich 套件
這次改動讓好奇心流程：
能夠安全地執行（有遞迴限制）
方便追蹤執行狀態（透過視覺化）
可以直接執行測試（透過 python pipelines_sam.py）